### PR TITLE
Update test runner to work with use context essentials2020

### DIFF
--- a/tests/all-fail/all-fail-test.arr
+++ b/tests/all-fail/all-fail-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("all-fail.arr")
 
 check "year not divisible by 4 in common year":

--- a/tests/all-fail/all-fail.arr
+++ b/tests/all-fail/all-fail.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 provide: leap end
 
 fun leap(year):

--- a/tests/all-fail/expected_results.json
+++ b/tests/all-fail/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "message": "all-fail-test.arr:3:0-5:3: year not divisible by 4 in common year (0/1) \n\nline 4, column 2: failed because: \nValues not equal \"foo\" true\n\nall-fail-test.arr:7:0-9:3: year divisible by 2, not divisible by 4 in common year (0/1) \n\nline 8, column 2: failed because: \nValues not equal \"foo\" true\n\nPassed: 0; Failed: 2; Ended in Error: 0; Total: 2"
+  "message": "all-fail-test.arr:5:0-7:3: year not divisible by 4 in common year (0/1) \n\nline 6, column 2: failed because: \nValues not equal \"foo\" true\n\nall-fail-test.arr:9:0-11:3: year divisible by 2, not divisible by 4 in common year (0/1) \n\nline 10, column 2: failed because: \nValues not equal \"foo\" true\n\nPassed: 0; Failed: 2; Ended in Error: 0; Total: 2"
 }

--- a/tests/empty-file/empty-file-test.arr
+++ b/tests/empty-file/empty-file-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("empty-file.arr")
 
 check "year not divisible by 4 in common year":

--- a/tests/empty-file/expected_results.json
+++ b/tests/empty-file/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "message": "The identifier `leap` at empty-file-test.arr:4:2-4:6 is unbound. It is used but not previously defined.\nThere were compilation errors"
+  "message": "The identifier `leap` at empty-file-test.arr:6:2-6:6 is unbound. It is used but not previously defined.\nThere were compilation errors"
 }

--- a/tests/partial-fail/expected_results.json
+++ b/tests/partial-fail/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "message": "partial-fail-test.arr:3:0-5:3: year not divisible by 4 in common year (1/1) \n\n\npartial-fail-test.arr:7:0-9:3: year divisible by 2, not divisible by 4 in common year (0/1) \n\nline 8, column 2: failed because: \nValues not different true true\n\nPassed: 1; Failed: 1; Ended in Error: 0; Total: 2"
+  "message": "partial-fail-test.arr:5:0-7:3: year not divisible by 4 in common year (1/1) \n\n\npartial-fail-test.arr:9:0-11:3: year divisible by 2, not divisible by 4 in common year (0/1) \n\nline 10, column 2: failed because: \nValues not different true true\n\nPassed: 1; Failed: 1; Ended in Error: 0; Total: 2"
 }

--- a/tests/partial-fail/partial-fail-test.arr
+++ b/tests/partial-fail/partial-fail-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("partial-fail.arr")
 
 check "year not divisible by 4 in common year":

--- a/tests/success-multiple/success-multiple-test.arr
+++ b/tests/success-multiple/success-multiple-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("success-multiple.arr")
 
 check "year not divisible by 4 in common year":

--- a/tests/success-multiple/success-multiple.arr
+++ b/tests/success-multiple/success-multiple.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 provide: leap end
 
 fun leap(year):

--- a/tests/success-single/success-single-test.arr
+++ b/tests/success-single/success-single-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("success-single.arr")
 
 check "year not divisible by 4 in common year":

--- a/tests/success-single/success-single.arr
+++ b/tests/success-single/success-single.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 provide: leap end
 
 fun leap(year):

--- a/tests/syntax-error/expected_results.json
+++ b/tests/syntax-error/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "error",
-  "message": "Pyret didn't understand your program around syntax-error.arr:1:14-1:18 You may need to add or remove some text to fix your program. Look carefully before the highlighted text. Is there a missing colon (`:`), comma (`,`), string marker (`\"`), or keyword? Is there something there that shouldn’t be?"
+  "message": "Pyret didn't understand your program around syntax-error.arr:3:14-3:18 You may need to add or remove some text to fix your program. Look carefully before the highlighted text. Is there a missing colon (`:`), comma (`,`), string marker (`\"`), or keyword? Is there something there that shouldn’t be?"
 }

--- a/tests/syntax-error/syntax-error-test.arr
+++ b/tests/syntax-error/syntax-error-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("syntax-error.arr")
 
 check "year not divisible by 4 in common year":

--- a/tests/syntax-error/syntax-error.arr
+++ b/tests/syntax-error/syntax-error.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 provide: leap eend
 
 fun leap(year):


### PR DESCRIPTION
Going forward, I want to use the essentials2020 context for all Pyret files. That's what pyret-npm supports at the moment, and code.pyret.org supports both essentials2020 and essentials2021. The current test-runner uses pyret-npm 0.0.23, not the recently-updated 0.0.25 which resolves a serious bug that precluded me from doing this before.