### PR TITLE
Fix unclear example about enabling a pending test

### DIFF
--- a/tests/all-fail/all-fail-test.arr
+++ b/tests/all-fail/all-fail-test.arr
@@ -23,7 +23,7 @@ end
 #|
   Code to run each test. Each line corresponds to a test above and whether it should be run.
   To mark a test to be run, replace `false` with `true` on that same line after the comma.
-  test(test-a, true) will be run. (test-b, false) will be skipped.
+  test(test-a, true) will be run. test(test-a, false) will be skipped.
 |#
 
 data TestRun: test(run, active) end

--- a/tests/empty-file/empty-file-test.arr
+++ b/tests/empty-file/empty-file-test.arr
@@ -17,7 +17,7 @@ end
 #|
   Code to run each test. Each line corresponds to a test above and whether it should be run.
   To mark a test to be run, replace `false` with `true` on that same line after the comma.
-  test(test-a, true) will be run. (test-b, false) will be skipped.
+  test(test-a, true) will be run. test(test-a, false) will be skipped.
 |#
 
 data TestRun: test(run, active) end

--- a/tests/partial-fail/partial-fail-test.arr
+++ b/tests/partial-fail/partial-fail-test.arr
@@ -23,7 +23,7 @@ end
 #|
   Code to run each test. Each line corresponds to a test above and whether it should be run.
   To mark a test to be run, replace `false` with `true` on that same line after the comma.
-  test(test-a, true) will be run. (test-b, false) will be skipped.
+  test(test-a, true) will be run. test(test-a, false) will be skipped.
 |#
 
 data TestRun: test(run, active) end

--- a/tests/success-multiple/success-multiple-test.arr
+++ b/tests/success-multiple/success-multiple-test.arr
@@ -23,7 +23,7 @@ end
 #|
   Code to run each test. Each line corresponds to a test above and whether it should be run.
   To mark a test to be run, replace `false` with `true` on that same line after the comma.
-  test(test-a, true) will be run. (test-b, false) will be skipped.
+  test(test-a, true) will be run. test(test-a, false) will be skipped.
 |#
 
 data TestRun: test(run, active) end

--- a/tests/success-single/success-single-test.arr
+++ b/tests/success-single/success-single-test.arr
@@ -17,7 +17,7 @@ end
 #|
   Code to run each test. Each line corresponds to a test above and whether it should be run.
   To mark a test to be run, replace `false` with `true` on that same line after the comma.
-  test(test-a, true) will be run. (test-b, false) will be skipped.
+  test(test-a, true) will be run. test(test-a, false) will be skipped.
 |#
 
 data TestRun: test(run, active) end

--- a/tests/syntax-error/syntax-error-test.arr
+++ b/tests/syntax-error/syntax-error-test.arr
@@ -17,7 +17,7 @@ end
 #|
   Code to run each test. Each line corresponds to a test above and whether it should be run.
   To mark a test to be run, replace `false` with `true` on that same line after the comma.
-  test(test-a, true) will be run. (test-b, false) will be skipped.
+  test(test-a, true) will be run. test(test-a, false) will be skipped.
 |#
 
 data TestRun: test(run, active) end


### PR DESCRIPTION
This PR fixes some unclear text that I already accounted for while updating the track's test files. I also want to rebuild the test-runner image to grab pyret-npm v.0.27, published five hours ago. That version fixes a bug where pyret-npm couldn't find the math library, and that was precluding me from merging in exercism/pyret#79 in good conscience. I didn't use the math library but surely someone will in their solution.