### PR TITLE
Add tests that a module can be included

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:3.17
+ARG PYRET_NPM_VERSION=0.0.27
 
 # install packages required to run the tests
 RUN apk add --no-cache jq coreutils nodejs npm && \
-    npm install -g pyret-npm
+    npm install -g pyret-npm@$PYRET_NPM_VERSION
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/tests/success-can-include-module/expected_results.json
+++ b/tests/success-can-include-module/expected_results.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "status": "pass"
+}

--- a/tests/success-can-include-module/success-can-include-module-test.arr
+++ b/tests/success-can-include-module/success-can-include-module-test.arr
@@ -1,0 +1,27 @@
+use context essentials2020
+
+include file("success-can-include-module.arr")
+
+#|
+  When working offline, all tests except the first one are skipped by default.
+  Once you get the first test running, unskip the next one until all tests pass locally.
+  Check the block comment below for further details.
+|#
+
+fun can-include-a-module():
+  check "can include a module without error":
+    include-math-module() is true
+  end
+end
+
+#|
+  Code to run each test. Each line corresponds to a test above and whether it should be run.
+  To mark a test to be run, replace `false` with `true` on that same line after the comma.
+  test(test-a, true) will be run. test(test-a, false) will be skipped.
+|#
+
+data TestRun: test(run, active) end
+
+[list: 
+  test(can-include-a-module, true)
+].each(lam(t): when t.active: t.run() end end)

--- a/tests/success-can-include-module/success-can-include-module.arr
+++ b/tests/success-can-include-module/success-can-include-module.arr
@@ -1,0 +1,7 @@
+provide: include-math-module end
+
+include math
+
+fun include-math-module():
+  true
+end


### PR DESCRIPTION
This previously wasn't a test because the modules we were using (mainly lists and string-dict) were working fine. However, the math module didn't work recently so this makes sure the test runner can import it. My expectation is that we add test cases in the future to `success-can-include-module-test.arr` for any other modules we find aren't importable. 